### PR TITLE
np-init-cli 2.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# `$ np-init` [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/np-init-cli.svg)](https://www.npmjs.com/package/np-init-cli) [![Downloads](https://img.shields.io/npm/dt/np-init-cli.svg)](https://www.npmjs.com/package/np-init-cli) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# `$ np-init`
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/np-init-cli.svg)](https://www.npmjs.com/package/np-init-cli) [![Downloads](https://img.shields.io/npm/dt/np-init-cli.svg)](https://www.npmjs.com/package/np-init-cli) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > CLI for starting a new npm package.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "np-init-cli",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "CLI for starting a new npm package.",
   "main": "cli.js",
   "bin": {
@@ -40,6 +40,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
